### PR TITLE
Webpack config for production - Error in build with non ascii files

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -152,7 +152,7 @@ getServerString = () => {
     if (err) {
       throw err;
     }
-    const fileContent = fs.readFileSync('/bundle.js').toString('ascii');
+    const fileContent = fs.readFileSync('/bundle.js').toString('utf-8');
     // Using eval because we can't require from `memory-fs`
     data = requireFromString(fileContent);
     sync = false;


### PR DESCRIPTION
Before, when we make a build for production environment and our js files contains non ascii characters like ñ, í, ..., there was an error in files generation.

> ERROR in Template execution failed: SyntaxError: Invalid or unexpected token
>
> ERROR in   Error: :44660
>    'b'': 16,
>        ^^^^^^
>  SyntaxError: Invalid or unexpected token

In webpack config, now toString transform bundle to utf-8 instead of ascii (used in build for production), so the error is solved, and final files including non ascii characters render ok in browsers