### PR TITLE
added support for compass, for better support for already written sas…

### DIFF
--- a/bin/get-webpack-config.js
+++ b/bin/get-webpack-config.js
@@ -146,7 +146,10 @@ const getWebpackConfig = (options = ({}), privateOptions = ({})) => {
                 }
               },
               {
-                loader: 'sass-loader'
+                loader: 'sass-loader',
+                options: {
+                  includePaths: ['node_modules/compass-mixins/lib']
+                },
               }
             ],
             fallback: 'style-loader'

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "babel-preset-react-hmre": "^1.1.1",
     "babel-preset-stage-2": "^6.18.0",
     "babel-runtime": "^6.20.0",
+    "compass-mixins": "^0.12.10",
     "css-loader": "^0.27.3",
     "deasync": "^0.1.7",
     "eslint": "^3.13.1",


### PR DESCRIPTION
added support for [Compass](http://compass-style.org/), for better support for already written sass projects (which are already supported).
the support for Compass does not include sprites generation.

followed the guidelines of sass-loader contributor:
webpack-contrib/sass-loader#26